### PR TITLE
[LOL-7]Carrousel Hero 3

### DIFF
--- a/Front/src/app/details/player-details/player-details.component.html
+++ b/Front/src/app/details/player-details/player-details.component.html
@@ -19,7 +19,7 @@
     </div>
   </div>
   <div class="row mt-2">
-    @if(leagueEntriesSignal().length){ @for (leagueEntry of leagueEntriesSignal(); track $index; let i = $index) {
+    @for (leagueEntry of leagueEntriesSignal(); track $index; let i = $index) {
     <div data-test="bloc-data-league-entry" class="col-6 league-entry" [ngClass]="{ 'first-entry': i === 0, 'second-entry': i === 1 }">
       <h3 class="text-center">{{ leagueEntry.queueType }}</h3>
       <div class="data mt-4 pt-4 pb-4">
@@ -31,7 +31,21 @@
         <img class="img-rank" alt="tier emblem" [src]="computeTierEmblem(leagueEntry.tier)" />
       </div>
     </div>
-    }}@else {
+    @if(isUnrankedFlex){
+    <div class="col-6 league-entry">
+      <h3 class="text-center">RANKED_FLEX_SR</h3>
+      <div class="data mt-4 pt-4 pb-4">
+        <p data-test="bloc_unranked_flex" class="text-center">Ce joueur n'est pas encore classé en Ranked Flex</p>
+      </div>
+    </div>
+    } @if(isUnrankedSoloQ){
+    <div class="col-6 league-entry">
+      <h3 class="text-center">RANKED_SOLO_5x5</h3>
+      <div class="data mt-4 pt-4 pb-4">
+        <p data-test="bloc-unranked-solo" class="text-center">Ce joueur n'est pas encore classé en Ranked Solo</p>
+      </div>
+    </div>
+    } }@if(!leagueEntriesSignal().length) {
     <div data-test="bloc-default-no-data-league-entry" class="text-center mt-2">
       <h3>Il n'y a pas d'informations sur ce joueur.</h3>
       <p>Il n'a peut être pas encore joué de parties classées ou est peut être inactif.</p>

--- a/Front/src/app/details/player-details/player-details.component.spec.ts
+++ b/Front/src/app/details/player-details/player-details.component.spec.ts
@@ -321,4 +321,116 @@ describe('PlayerDetailsComponent', () => {
     );
     expect(blocDataLeagueEntry).toBeFalsy();
   });
+
+  it('should display a message if data is missing for RANKED_SOLO_5x5', () => {
+    // GIVEN
+    const mockAccountDTO = {
+      puuid: 'mock-puuid',
+      gameName: 'test',
+      tagLine: 'euw',
+      summonerId: 'mock-summoner-id',
+      profileIconId: 1234,
+      summonerLevel: 30,
+      revisionDate: 1680000000000,
+      id: 'mock-id',
+    } as AccountDTO;
+
+    const mockSummonerDTO = {
+      id: 'mock-summoner-id',
+      accountId: 'mock-account-id',
+      puuid: 'mock-puuid',
+      name: 'test',
+      profileIconId: 1234,
+      revisionDate: 1680000000000,
+      summonerLevel: 30,
+    } as SummonerDTO;
+
+    const mockLeagueEntryDTO = {
+      leagueId: 'mock-league-id',
+      puuid: 'mock-puuid',
+      queueType: 'RANKED_FLEX_SR',
+      tier: 'GOLD',
+      rank: 'IV',
+      summonerId: 'mock-summoner-id',
+      summonerName: 'test',
+      leaguePoints: 50,
+      wins: 20,
+      losses: 15,
+      veteran: false,
+      inactive: false,
+      freshBlood: true,
+      hotStreak: false,
+    } as LeagueEntryDTO;
+
+    spyOn(playerService, 'getAccountByRiotId').and.returnValue(of(mockAccountDTO));
+    spyOn(playerService, 'getSummonerByPuuid').and.returnValue(of(mockSummonerDTO));
+    spyOn(playerService, 'getLeagueEntryByPuuid').and.returnValue(of([mockLeagueEntryDTO]));
+    spyOn(playerService, 'getChampionMasteriesDTO').and.returnValue(of([]));
+
+    // WHEN
+    fixture.detectChanges();
+
+    // THEN
+    const blocUnrankedSolo = getByDataTestAttr(fixture.debugElement, 'bloc-unranked-solo');
+    expect(blocUnrankedSolo).toBeTruthy();
+    expect(blocUnrankedSolo?.textContent).toEqual("Ce joueur n'est pas encore classé en Ranked Solo");
+    expect(component.isUnrankedSoloQ).toBeTrue();
+    expect(component.isUnrankedFlex).toBeFalse();
+  });
+
+  it('should display a message if data is missing for RANKED_FLEX_SR', () => {
+    // GIVEN
+    const mockAccountDTO = {
+      puuid: 'mock-puuid',
+      gameName: 'test',
+      tagLine: 'euw',
+      summonerId: 'mock-summoner-id',
+      profileIconId: 1234,
+      summonerLevel: 30,
+      revisionDate: 1680000000000,
+      id: 'mock-id',
+    } as AccountDTO;
+
+    const mockSummonerDTO = {
+      id: 'mock-summoner-id',
+      accountId: 'mock-account-id',
+      puuid: 'mock-puuid',
+      name: 'test',
+      profileIconId: 1234,
+      revisionDate: 1680000000000,
+      summonerLevel: 30,
+    } as SummonerDTO;
+
+    const mockLeagueEntryDTO = {
+      leagueId: 'mock-league-id',
+      puuid: 'mock-puuid',
+      queueType: 'RANKED_SOLO_5x5',
+      tier: 'GOLD',
+      rank: 'IV',
+      summonerId: 'mock-summoner-id',
+      summonerName: 'test',
+      leaguePoints: 50,
+      wins: 20,
+      losses: 15,
+      veteran: false,
+      inactive: false,
+      freshBlood: true,
+      hotStreak: false,
+    } as LeagueEntryDTO;
+
+    spyOn(playerService, 'getAccountByRiotId').and.returnValue(of(mockAccountDTO));
+    spyOn(playerService, 'getSummonerByPuuid').and.returnValue(of(mockSummonerDTO));
+    spyOn(playerService, 'getLeagueEntryByPuuid').and.returnValue(of([mockLeagueEntryDTO]));
+    spyOn(playerService, 'getChampionMasteriesDTO').and.returnValue(of([]));
+
+    // WHEN
+    fixture.detectChanges();
+
+    // THEN
+    const blocUnrankedFlex = getByDataTestAttr(fixture.debugElement, 'bloc_unranked_flex');
+    expect(blocUnrankedFlex).toBeTruthy();
+    expect(blocUnrankedFlex?.textContent).toEqual("Ce joueur n'est pas encore classé en Ranked Flex");
+    expect(component.isUnrankedSoloQ).toBeFalse();
+    expect(component.isUnrankedFlex).toBeTrue();
+  });
 });

--- a/Front/src/app/details/player-details/player-details.component.ts
+++ b/Front/src/app/details/player-details/player-details.component.ts
@@ -7,6 +7,7 @@ import { GetVersionsService } from '../../services/versions/get-versions.service
 import { LeagueEntryDTO } from '../../common/models/LeagueEntryDTO';
 import { CommonModule } from '@angular/common';
 import { ChampionMasteryDto } from '../../common/models/ChampionMasteryDto';
+import { QueueTypeEnum } from '../../common/constants/queueTypeEnum';
 
 @Component({
   selector: 'app-player-details',
@@ -23,6 +24,8 @@ export class PlayerDetailsComponent {
   leagueEntriesSignal: WritableSignal<LeagueEntryDTO[]> = signal([]);
   championMasteriesSignal: WritableSignal<ChampionMasteryDto[]> = signal([]);
   urlBackgroundBannerSignal: WritableSignal<string> = signal('');
+  isUnrankedFlex = false;
+  isUnrankedSoloQ = false;
   tagLine: string = '';
   isLoading = false;
 
@@ -53,6 +56,8 @@ export class PlayerDetailsComponent {
       .pipe(
         switchMap(({ leagueEntries, puuid }) => {
           this.leagueEntriesSignal.set(leagueEntries);
+          this.isUnrankedFlex = leagueEntries.find((entry) => entry.queueType === QueueTypeEnum.RANKED_FLEX_SR) ? false : true;
+          this.isUnrankedSoloQ = leagueEntries.find((entry) => entry.queueType === QueueTypeEnum.RANKED_SOLO_5x5) ? false : true;
           return this.playerService.getChampionMasteriesDTO(puuid);
         })
       )

--- a/Front/src/app/home/hero/hero.component.html
+++ b/Front/src/app/home/hero/hero.component.html
@@ -2,8 +2,13 @@
 <div class="d-flex justify-content-center">
   <ngb-carousel class="w-50" [interval]="4000" [pauseOnHover]="true" [wrap]="true">
     <ng-template ngbSlide>
-      <div class="element-carrousel-challenger">
-        <div class="row">
+      <div
+        data-test="bloc-best-challenger-player-soloQ"
+        (click)="goToPlayerDataLeagueEntries(gameNameBestChalPlayerSoloQ!, tagLineChalSoloQPlayer!)"
+        [ngStyle]="{ 'background-image': urlBackgroundBannerSoloQSignal() }"
+        class="element-carrousel-challenger"
+      >
+        <div class="row h-100">
           <div class="col d-flex justify-content-center mt-3">
             <div class="profilIcone">
               <img
@@ -19,20 +24,25 @@
             </div>
             <h2 class="text-center ms-2">{{ gameNameBestChalPlayerSoloQ }}</h2>
           </div>
-          <div class="row">
-            <div class="col text-center">
-              <span>Numéro 1 Solo Queue EUW - {{ firstChallengerPlayerSoloQSignal()?.leaguePoints + " LP" }}</span
-              ><br />
-              <span>{{ firstChallengerPlayerSoloQSignal()?.wins + " V /" + firstChallengerPlayerSoloQSignal()?.losses + " D" }} </span>
-              <br />
+          <div class="row d-flex align-items-end">
+            <div class="col d-flex justify-content-between">
+              <span class="text-hero ms-2 ps-2">Numéro 1 Solo Queue EUW - {{ firstChallengerPlayerSoloQSignal()?.leaguePoints + " LP" }}</span>
+              <span class="text-hero ps-2 pe-2">
+                {{ firstChallengerPlayerSoloQSignal()?.wins + " V /" + firstChallengerPlayerSoloQSignal()?.losses + " D" }}
+              </span>
             </div>
           </div>
         </div>
       </div>
     </ng-template>
     <ng-template ngbSlide>
-      <div class="element-carrousel-challenger">
-        <div class="row">
+      <div
+        data-test="bloc-best-challenger-player-flexQ"
+        (click)="goToPlayerDataLeagueEntries(gameNameBestChalPlayerFlex!, tagLineChalFlexPlayer!)"
+        [ngStyle]="{ 'background-image': urlBackgroundBannerFlexQSignal() }"
+        class="element-carrousel-challenger"
+      >
+        <div class="row h-100">
           <div class="col d-flex justify-content-center mt-3">
             <div class="profilIcone">
               <img
@@ -48,12 +58,12 @@
             </div>
             <h2 class="text-center ms-2">{{ gameNameBestChalPlayerFlex }}</h2>
           </div>
-          <div class="row">
-            <div class="col text-center">
-              <span>Numéro 1 Flex Queue EUW - {{ firstChallengerPlayerFlexSignal()?.leaguePoints + " LP" }}</span
-              ><br />
-              <span>{{ firstChallengerPlayerFlexSignal()?.wins + " V /" + firstChallengerPlayerFlexSignal()?.losses + " D" }} </span>
-              <br />
+          <div class="row d-flex align-items-end">
+            <div class="col d-flex justify-content-between">
+              <span class="text-hero ms-2 ps-2 pe-2">Numéro 1 Flex Queue EUW - {{ firstChallengerPlayerFlexSignal()?.leaguePoints + " LP" }}</span>
+              <span class="text-hero ps-2 pe-2"
+                >{{ firstChallengerPlayerFlexSignal()?.wins + " V /" + firstChallengerPlayerFlexSignal()?.losses + " D" }}
+              </span>
             </div>
           </div>
         </div>

--- a/Front/src/app/home/hero/hero.component.scss
+++ b/Front/src/app/home/hero/hero.component.scss
@@ -3,11 +3,13 @@
   border: 1px solid #c8aa6e;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  background: linear-gradient(85deg, #0a1428 0%, #1e283e 100%);
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+  cursor: pointer;
 }
 
 h2 {
-  color: #b0892b;
   font-family: "Trajan Pro", serif;
   text-shadow: 1px 1px 0 #3d331b;
   margin-bottom: 1.5rem;
@@ -26,4 +28,9 @@ h2 {
 
 .profilIcone img {
   width: 100%;
+}
+
+.text-hero {
+  background-color: var(--color-black-trans-2);
+  text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.4);
 }

--- a/Front/src/app/home/hero/hero.component.spec.ts
+++ b/Front/src/app/home/hero/hero.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { HeroComponent } from './hero.component';
 import { PlayersService } from '../../services/players/players.service';
@@ -8,20 +8,28 @@ import { LeagueListDTO } from '../../common/models/leagueListDTO';
 import { AccountDTO } from '../../common/models/accountDTO';
 import { SummonerDTO } from '../../common/models/summonerDTO';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ChampionMasteryDto } from '../../common/models/ChampionMasteryDto';
+import { clickButtonByDataTestAttr, getByDataTestAttr } from '../../common/utils/utils-tests';
+import { Router } from '@angular/router';
+import { GetVersionsService } from '../../services/versions/get-versions.service';
 
 describe('HeroComponentComponent', () => {
   let component: HeroComponent;
   let fixture: ComponentFixture<HeroComponent>;
   let playerservice: PlayersService;
+  let getVersionService: GetVersionsService;
+  let router: Router;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HeroComponent],
-      providers: [PlayersService, provideHttpClient(), provideHttpClientTesting()],
+      providers: [GetVersionsService, PlayersService, provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     playerservice = TestBed.inject(PlayersService);
+    getVersionService = TestBed.inject(GetVersionsService);
     fixture = TestBed.createComponent(HeroComponent);
+    router = TestBed.inject(Router);
     component = fixture.componentInstance;
   });
 
@@ -110,6 +118,7 @@ describe('HeroComponentComponent', () => {
       profileIconId: 123,
       summonerLevel: 30,
     } as SummonerDTO;
+    spyOn(playerservice, 'getChampionMasteriesDTO').and.returnValue(of([]));
     spyOn(playerservice, 'getAccountByPuuid').and.returnValue(of(accountDTOMock));
     const getSummonerSpy = spyOn(playerservice, 'getSummonerByPuuid').and.returnValue(of(summonerDTOMock));
 
@@ -118,7 +127,7 @@ describe('HeroComponentComponent', () => {
 
     // THEN
     expect(getSummonerSpy).toHaveBeenCalled();
-    expect(component.firstChallengerSummonerSoloQSignal()).toBe(summonerDTOMock);
+    expect(component.firstChallengerSummonerSoloQSignal()).toEqual(summonerDTOMock);
   });
 
   it('should call getLeagueChallengerDataFlex', () => {
@@ -150,7 +159,97 @@ describe('HeroComponentComponent', () => {
     expect(component.gameNameBestChalPlayerFlex).toEqual('test name');
   });
 
-  it('should call getSummonerByPuuid and get the summonerDTO of the best player Challenger flexQ', () => {
+  it('should call getChampionMasteriesDTO and compute url background bannner case flexQ', () => {
+    // GIVEN
+    const championMasteriesDTOMock = {
+      puuid: '12345',
+      championId: 266,
+      championLevel: 7,
+      championPoints: 123456,
+      lastPlayTime: 1680000000000,
+      championPointsSinceLastLevel: 0,
+      championPointsUntilNextLevel: 0,
+      markRequiredForNextLevel: 12,
+      chestGranted: true,
+    } as ChampionMasteryDto;
+
+    spyOn(playerservice, 'getLeagueChallengerDataFlexQ').and.returnValue(of(mockLeagueListDTOFlex));
+    const accountDTOMock = { puuid: '12345', gameName: 'test name', tagLine: 'EUW' } as AccountDTO;
+    const summonerDTOMock = {
+      puuid: '12345',
+      id: 'summoner123',
+      profileIconId: 123,
+      summonerLevel: 30,
+    } as SummonerDTO;
+    spyOn(playerservice, 'getAccountByPuuid').and.returnValue(of(accountDTOMock));
+    spyOn(playerservice, 'getSummonerByPuuid').and.returnValue(of(summonerDTOMock));
+    const getChampionMasteriesDTOSpy = spyOn(playerservice, 'getChampionMasteriesDTO').and.returnValue(of([championMasteriesDTOMock]));
+
+    // WHEN
+    fixture.detectChanges();
+
+    // THEN
+    expect(getChampionMasteriesDTOSpy).toHaveBeenCalledWith('12345');
+    expect(component.urlBackgroundBannerFlexQSignal()).toEqual('url(https://lolg-cdn.porofessor.gg/img/d/champion-banners/266.jpg)');
+  });
+
+  it('should call getChampionMasteriesDTO and compute url background bannner case soloQ', () => {
+    // GIVEN
+    const championMasteriesDTOMock = {
+      puuid: '12345',
+      championId: 266,
+      championLevel: 7,
+      championPoints: 123456,
+      lastPlayTime: 1680000000000,
+      championPointsSinceLastLevel: 0,
+      championPointsUntilNextLevel: 0,
+      markRequiredForNextLevel: 12,
+      chestGranted: true,
+    } as ChampionMasteryDto;
+
+    spyOn(playerservice, 'getLeagueChallengerDataSoloQ').and.returnValue(of(mockLeagueListDTO));
+    const accountDTOMock = { puuid: '12345', gameName: 'test name', tagLine: 'EUW' } as AccountDTO;
+    const summonerDTOMock = {
+      puuid: '12345',
+      id: 'summoner123',
+      profileIconId: 123,
+      summonerLevel: 30,
+    } as SummonerDTO;
+    spyOn(playerservice, 'getAccountByPuuid').and.returnValue(of(accountDTOMock));
+    spyOn(playerservice, 'getSummonerByPuuid').and.returnValue(of(summonerDTOMock));
+    const getChampionMasteriesDTOSpy = spyOn(playerservice, 'getChampionMasteriesDTO').and.returnValue(of([championMasteriesDTOMock]));
+
+    // WHEN
+    fixture.detectChanges();
+
+    // THEN
+    expect(getChampionMasteriesDTOSpy).toHaveBeenCalledWith('12345');
+    expect(component.urlBackgroundBannerSoloQSignal()).toEqual('url(https://lolg-cdn.porofessor.gg/img/d/champion-banners/266.jpg)');
+  });
+
+  it('should call getChampionMasteriesDTO and compute a default url background bannner if no data case soloQ', () => {
+    // GIVEN
+    spyOn(playerservice, 'getLeagueChallengerDataSoloQ').and.returnValue(of(mockLeagueListDTO));
+    const accountDTOMock = { puuid: '12345', gameName: 'test name', tagLine: 'EUW' } as AccountDTO;
+    const summonerDTOMock = {
+      puuid: '12345',
+      id: 'summoner123',
+      profileIconId: 123,
+      summonerLevel: 30,
+    } as SummonerDTO;
+    spyOn(playerservice, 'getAccountByPuuid').and.returnValue(of(accountDTOMock));
+    spyOn(playerservice, 'getSummonerByPuuid').and.returnValue(of(summonerDTOMock));
+    const getChampionMasteriesDTOSpy = spyOn(playerservice, 'getChampionMasteriesDTO').and.returnValue(of([]));
+
+    // WHEN
+    fixture.detectChanges();
+
+    // THEN
+    expect(getChampionMasteriesDTOSpy).toHaveBeenCalledWith('12345');
+    expect(component.urlBackgroundBannerSoloQSignal()).toEqual('url(images/default-banner.png)');
+  });
+
+  it('should call getChampionMasteriesDTO and compute a default url background bannner if no data case flexQ', () => {
     // GIVEN
     spyOn(playerservice, 'getLeagueChallengerDataFlexQ').and.returnValue(of(mockLeagueListDTOFlex));
     const accountDTOMock = { puuid: '12345', gameName: 'test name', tagLine: 'EUW' } as AccountDTO;
@@ -161,13 +260,57 @@ describe('HeroComponentComponent', () => {
       summonerLevel: 30,
     } as SummonerDTO;
     spyOn(playerservice, 'getAccountByPuuid').and.returnValue(of(accountDTOMock));
-    const getSummonerSpy = spyOn(playerservice, 'getSummonerByPuuid').and.returnValue(of(summonerDTOMock));
+    spyOn(playerservice, 'getSummonerByPuuid').and.returnValue(of(summonerDTOMock));
+    const getChampionMasteriesDTOSpy = spyOn(playerservice, 'getChampionMasteriesDTO').and.returnValue(of([]));
 
     // WHEN
     fixture.detectChanges();
 
     // THEN
-    expect(getSummonerSpy).toHaveBeenCalledWith('12345');
-    expect(component.firstChallengerSummonerFlexSignal()).toBe(summonerDTOMock);
+    expect(getChampionMasteriesDTOSpy).toHaveBeenCalledWith('12345');
+    expect(component.urlBackgroundBannerFlexQSignal()).toEqual('url(images/default-banner.png)');
+  });
+
+  ['bloc-best-challenger-player-soloQ', 'bloc-best-challenger-player-flexQ'].forEach((dataTest) => {
+    it('should redirect user to DetailComponent when click on best challenger player from slides', () => {
+      // GIVEN
+      const accountDTOMock = { puuid: '12345', gameName: 'test name', tagLine: 'EUW' } as AccountDTO;
+      const summonerDTOMock = {
+        puuid: '12345',
+        id: 'summoner123',
+        profileIconId: 123,
+        summonerLevel: 30,
+      } as SummonerDTO;
+
+      const championMasteriesDTOMock = {
+        puuid: '12345',
+        championId: 266,
+        championLevel: 7,
+        championPoints: 123456,
+        lastPlayTime: 1680000000000,
+        championPointsSinceLastLevel: 0,
+        championPointsUntilNextLevel: 0,
+        markRequiredForNextLevel: 12,
+        chestGranted: true,
+      } as ChampionMasteryDto;
+
+      getVersionService.lastVersionlolDTOSignal.set('0');
+      spyOn(playerservice, 'getLeagueChallengerDataSoloQ').and.returnValue(of(mockLeagueListDTO));
+      spyOn(playerservice, 'getLeagueChallengerDataFlexQ').and.returnValue(of(mockLeagueListDTOFlex));
+      spyOn(playerservice, 'getAccountByPuuid').and.returnValue(of(accountDTOMock));
+      spyOn(playerservice, 'getSummonerByPuuid').and.returnValue(of(summonerDTOMock));
+      spyOn(playerservice, 'getChampionMasteriesDTO').and.returnValue(of([championMasteriesDTOMock]));
+
+      const routerSpy = spyOn(router, 'navigate').and.stub();
+      fixture.detectChanges();
+      const slideClickable = getByDataTestAttr(fixture.debugElement, dataTest);
+
+      // WHEN
+      slideClickable?.click();
+
+      // THEN
+      expect(routerSpy).toHaveBeenCalledWith(['Detail/test name#EUW']);
+      fixture.destroy();
+    });
   });
 });

--- a/Front/src/app/home/home.component.html
+++ b/Front/src/app/home/home.component.html
@@ -16,7 +16,6 @@
               @for (champion of freeChampionsDataSignal(); track champion.id) {
               <div class="m-1 card champion-card text-white overflow-hidden position-relative">
                 <img
-                  [title]="champion.name"
                   [alt]="champion.name"
                   [src]="'https://ddragon.leagueoflegends.com/cdn/' + lastVersionLolSignal() + '/img/champion/' + champion.image.full"
                 />
@@ -47,10 +46,9 @@
         <div ngbAccordionBody>
           <ng-template>
             <div class="row d-flex justify-content-start">
-              @for (champion of freeChampionsForBeginnersDataSignal(); track champion.id) {s
+              @for (champion of freeChampionsForBeginnersDataSignal(); track champion.id) {
               <div class="m-1 card champion-card text-white overflow-hidden position-relative">
                 <img
-                  [title]="champion.name"
                   [alt]="champion.name"
                   [src]="'https://ddragon.leagueoflegends.com/cdn/' + lastVersionLolSignal() + '/img/champion/' + champion.image.full"
                 />

--- a/Front/src/app/navigation/navigation-component.html
+++ b/Front/src/app/navigation/navigation-component.html
@@ -4,7 +4,15 @@
   </div>
   <div class="col-4 input-search-container d-flex justify-content-end align-items-center">
     <div class="container-input-search">
-      <input data-test="search-summoner-input" (keyup.enter)="onSearch()" #searchSummoner placeholder="Exemple#TAG" type="text" />
+      <input
+        ngbTooltip="Rechercher un joueur"
+        placement="bottom"
+        data-test="search-summoner-input"
+        (keyup.enter)="onSearch()"
+        #searchSummoner
+        placeholder="Exemple#TAG"
+        type="text"
+      />
       <i data-test="search-summoner-icone" (click)="onSearch()" class="bi bi-search search-icone"></i>
     </div>
   </div>

--- a/Front/src/app/navigation/navigation-component.ts
+++ b/Front/src/app/navigation/navigation-component.ts
@@ -1,10 +1,12 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { INVALID_SEARCH_SUMMONER_ERROR } from '../common/constants/errors';
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'app-navigation-component',
   standalone: true,
+  imports: [NgbTooltipModule],
   templateUrl: './navigation-component.html',
   styleUrl: './navigation-component.scss',
 })

--- a/Front/src/styles.scss
+++ b/Front/src/styles.scss
@@ -3,6 +3,7 @@
 :root {
   --color-gold-lol-1: #c8aa6e;
   --color-black-trans-1: #0a0a0a3f;
+  --color-black-trans-2: #0a0a0a98;
 }
 
 body,
@@ -35,4 +36,10 @@ html {
   background-color: #0a0a0a;
   padding: 2rem;
   border-radius: 12px;
+}
+
+.tooltip .tooltip-inner {
+  transform: translateY(-8px);
+  color: var(--color-gold-lol-1);
+  background-color: transparent;
 }


### PR DESCRIPTION
- Afficher en background la bannière du meilleur champion du joueur (en terme de points de maitrises).
- Au clique sur le joueur représenté depuis le Hero, redirige sur la page de détail du joueur (avec les league entries).
- Ajout d'une tooltip sur l'input de recherche d'un joueur