### PR TITLE
[TECH-10] Limiter les appels api pour Riot id

### DIFF
--- a/Back/src/main/java/com/league/league_infos/dao/entity/ParticipantMatchEntity.java
+++ b/Back/src/main/java/com/league/league_infos/dao/entity/ParticipantMatchEntity.java
@@ -112,6 +112,9 @@ public class ParticipantMatchEntity {
     @Column(name = "puuid", nullable = false)
     private String puuid;
 
+    @Column(name = "pseudo")
+    private String pseudo;
+
     @Column(name = "win", nullable = false)
     private boolean win;
 
@@ -389,6 +392,14 @@ public class ParticipantMatchEntity {
 
     public void setPuuid(String puuid) {
         this.puuid = puuid;
+    }
+
+    public String getPseudo() {
+        return pseudo;
+    }
+
+    public void setPseudo(String pseudo) {
+        this.pseudo = pseudo;
     }
 
     public boolean isWin() {

--- a/Back/src/main/java/com/league/league_infos/dto/match/ParticipantMatchDTO.java
+++ b/Back/src/main/java/com/league/league_infos/dto/match/ParticipantMatchDTO.java
@@ -34,6 +34,7 @@ public class ParticipantMatchDTO {
     private String teamPosition;
     private Boolean win;
     private ChallengesDTO challenges;
+    private String pseudo;
 
     public Integer getParticipantId() {
         return participantId;
@@ -299,6 +300,14 @@ public class ParticipantMatchDTO {
         this.challenges = challenges;
     }
 
+    public String getPseudo() {
+        return pseudo;
+    }
+
+    public void setPseudo(String pseudo) {
+        this.pseudo = pseudo;
+    }
+
     public static class Builder {
         private Integer participantId;
         private Integer profileIcon;
@@ -333,6 +342,7 @@ public class ParticipantMatchDTO {
         private String teamPosition;
         private Boolean win;
         private ChallengesDTO challenges;
+        private String pseudo;
 
         public ParticipantMatchDTO.Builder participantId(Integer participantId) {
             this.participantId = participantId;
@@ -499,6 +509,11 @@ public class ParticipantMatchDTO {
             return this;
         }
 
+        public ParticipantMatchDTO.Builder pseudo(String pseudo) {
+            this.pseudo = pseudo;
+            return this;
+        }
+
         public ParticipantMatchDTO build() {
             ParticipantMatchDTO dto = new ParticipantMatchDTO();
             dto.setParticipantId(this.participantId);
@@ -534,6 +549,7 @@ public class ParticipantMatchDTO {
             dto.setTeamPosition(this.teamPosition);
             dto.setWin(this.win);
             dto.setChallenges(this.challenges);
+            dto.setPseudo(this.pseudo);
             return dto;
         }
     }

--- a/Back/src/main/java/com/league/league_infos/mapper/ParticipantMatchMapper.java
+++ b/Back/src/main/java/com/league/league_infos/mapper/ParticipantMatchMapper.java
@@ -38,6 +38,7 @@ public class ParticipantMatchMapper {
         participantMatchEntity.setNeutralMinionsKilled(participantMatchDTO.getNeutralMinionsKilled());
         participantMatchEntity.setTotalMinionsKilled(participantMatchDTO.getTotalMinionsKilled());
         participantMatchEntity.setPuuid(participantMatchDTO.getPuuid());
+        participantMatchEntity.setPseudo(participantMatchDTO.getPseudo());
         participantMatchEntity.setProfileIcon(participantMatchDTO.getProfileIcon());
         participantMatchEntity.setTeamId(participantMatchDTO.getTeamId());
         participantMatchEntity.setTeamPosition(participantMatchDTO.getTeamPosition());
@@ -60,7 +61,7 @@ public class ParticipantMatchMapper {
     public static ParticipantMatchDTO participantMatchEntityToDTO(ParticipantMatchEntity participantMatchEntity) {
         Objects.requireNonNull(participantMatchEntity, "participantMatchEntity cannot be null");
         Objects.requireNonNull(participantMatchEntity.getIdParticipant(), "participantMatchEntity.participantId cannot be null");
-        
+
         ParticipantMatchDTO participantMatchDTO = new ParticipantMatchDTO();
         participantMatchDTO.setParticipantId(Math.toIntExact(participantMatchEntity.getIdParticipant()));
         participantMatchDTO.setAssists(participantMatchEntity.getAssists());
@@ -95,6 +96,7 @@ public class ParticipantMatchMapper {
         participantMatchDTO.setItem5(participantMatchEntity.getItem5());
         participantMatchDTO.setItem6(participantMatchEntity.getItem6());
         participantMatchDTO.setChallenges(ChallengesMapper.challengesEntityToDTO(participantMatchEntity.getChallengesEntity()));
+        participantMatchDTO.setPseudo(participantMatchEntity.getPseudo());
         return participantMatchDTO;
     }
 }

--- a/Back/src/main/java/com/league/league_infos/services/api/HistoryGamesService.java
+++ b/Back/src/main/java/com/league/league_infos/services/api/HistoryGamesService.java
@@ -1,9 +1,11 @@
 package com.league.league_infos.services.api;
 
+import com.league.league_infos.dto.match.MatchDTO;
+
 import java.util.List;
 
 public interface HistoryGamesService {
     List<String> getHistoryIds(String puuid, Integer queue);
 
-    void getMatchHistory(List<String> listMatchId);
+    List<MatchDTO> getMatchHistory(List<String> listMatchId);
 }

--- a/Back/src/main/java/com/league/league_infos/services/business/MatchDataProvider.java
+++ b/Back/src/main/java/com/league/league_infos/services/business/MatchDataProvider.java
@@ -1,7 +1,10 @@
 package com.league.league_infos.services.business;
 
 import com.league.league_infos.common.utils.CurrentLocalDateTime;
+import com.league.league_infos.dto.AccountDTO;
 import com.league.league_infos.dto.match.MatchDTO;
+import com.league.league_infos.dto.match.ParticipantMatchDTO;
+import com.league.league_infos.services.api.AccountService;
 import com.league.league_infos.services.api.HistoryGamesService;
 import com.league.league_infos.services.spi.HistoryPersistence;
 import org.springframework.stereotype.Service;
@@ -13,18 +16,23 @@ public class MatchDataProvider {
     private final HistoryGamesService historyRiotGamesService;
     private final HistoryPersistence historyPersistence;
     private final CurrentLocalDateTime currentLocalDateTime;
+    private final AccountService riotAccountService;
 
-    public MatchDataProvider(HistoryGamesService historyRiotGamesService, HistoryPersistence historyPersistence, CurrentLocalDateTime currentLocalDateTime) {
+    public MatchDataProvider(HistoryGamesService historyRiotGamesService, HistoryPersistence historyPersistence, CurrentLocalDateTime currentLocalDateTime,
+                             AccountService riotAccountService) {
         this.historyRiotGamesService = historyRiotGamesService;
         this.historyPersistence = historyPersistence;
         this.currentLocalDateTime = currentLocalDateTime;
+        this.riotAccountService = riotAccountService;
     }
 
     public List<MatchDTO> getMatchsHistory(String puuid, Integer queue) {
         List<MatchDTO> listMatchHistory = historyPersistence.findAllMatchByPuuidAndQueue(puuid, queue);
-        if (!wasResfreshedFromRiot(listMatchHistory)) {
+        if (listMatchHistory.isEmpty() || !wasResfreshedFromRiot(listMatchHistory)) {
             List<String> listGamesIds = historyRiotGamesService.getHistoryIds(puuid, queue);
-            historyRiotGamesService.getMatchHistory(listGamesIds);
+            List<MatchDTO> listMatchToPersist = historyRiotGamesService.getMatchHistory(listGamesIds);
+            updatePseudoFromFromCurrentParticipant(puuid, listMatchToPersist);
+            historyPersistence.persistAndRefreshFromRiotMatchHistory(listMatchToPersist);
         }
         return listMatchHistory;
     }
@@ -32,5 +40,14 @@ public class MatchDataProvider {
     private boolean wasResfreshedFromRiot(List<MatchDTO> matchs) {
         return matchs.stream().anyMatch(match ->
                 match.getInfo().getLastRefreshFromRiot() != null && match.getInfo().getLastRefreshFromRiot().isAfter(currentLocalDateTime.getCurrentLocalDateTime().minusHours(12)));
+    }
+
+    private void updatePseudoFromFromCurrentParticipant(String puuid, List<MatchDTO> listMatchToPersist) {
+        AccountDTO accountDTO = riotAccountService.getAccountByPuuid(puuid);
+        listMatchToPersist.forEach(match -> {
+            ParticipantMatchDTO currentParticipant = match.getInfo().getParticipants().stream().filter(participant ->
+                    participant.getPuuid().equals(puuid)).toList().getFirst();
+            currentParticipant.setPseudo(accountDTO.getGameName());
+        });
     }
 }

--- a/Back/src/main/java/com/league/league_infos/services/riot/RiotHistoryGamesService.java
+++ b/Back/src/main/java/com/league/league_infos/services/riot/RiotHistoryGamesService.java
@@ -4,7 +4,6 @@ import com.league.league_infos.common.constants.ApiRiotUrls;
 import com.league.league_infos.common.exceptions.BusinessException;
 import com.league.league_infos.dto.match.MatchDTO;
 import com.league.league_infos.services.api.HistoryGamesService;
-import com.league.league_infos.services.spi.HistoryPersistence;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
@@ -30,15 +29,13 @@ import static com.league.league_infos.common.constants.ErrorMessagesEnum.ERROR_B
 public class RiotHistoryGamesService implements HistoryGamesService {
 
     private final RestTemplate restTemplate;
-    private final HistoryPersistence historyPersistence;
 
     @Value("${app.game-history.max-count}")
     private int MAX_COUNT_MATCH_HISTORY;
 
     @Autowired
-    public RiotHistoryGamesService(RestTemplate restTemplate, HistoryPersistence historyPersistence) {
+    public RiotHistoryGamesService(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
-        this.historyPersistence = historyPersistence;
     }
 
     @Override
@@ -65,7 +62,7 @@ public class RiotHistoryGamesService implements HistoryGamesService {
     }
 
     @Override
-    public void getMatchHistory(List<String> listMatchId) {
+    public List<MatchDTO> getMatchHistory(List<String> listMatchId) {
 
         List<MatchDTO> listMatchDTO = new ArrayList<>();
         try {
@@ -79,7 +76,7 @@ public class RiotHistoryGamesService implements HistoryGamesService {
                 return result.getBody();
             }).toList();
 
-            historyPersistence.persistAndRefreshFromRiotMatchHistory(listMatchDTO);
+            return listMatchDTO;
 
         } catch (HttpClientErrorException | HttpServerErrorException ex) {
             if (ex.getStatusCode() == HttpStatus.NOT_FOUND) {

--- a/Back/src/main/resources/db/changelog/changes/db.changelog-update-table-T_PARTICIPANT_MATCH-add-column-pseudo.yml
+++ b/Back/src/main/resources/db/changelog/changes/db.changelog-update-table-T_PARTICIPANT_MATCH-add-column-pseudo.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 100120262347
+      author: VG
+      preConditions:
+        - not:
+            - columnExists:
+                tableName: T_PARTICIPANT_MATCH
+                columnName: pseudo
+          onFail: MARK_RAN
+      changes:
+        - addColumn:
+            tableName: T_PARTICIPANT_MATCH
+            columns:
+              - column:
+                  name: pseudo
+                  type: VARCHAR(255)

--- a/Back/src/main/resources/db/changelog/db.changelog-master.yml
+++ b/Back/src/main/resources/db/changelog/db.changelog-master.yml
@@ -17,3 +17,5 @@ databaseChangeLog:
       file: db/changelog/changes/db.changelog-update-table-T_PARTICIPANT_MATCH-add-column-meta_data_id.yml
   - include:
       file: db/changelog/changes/db.changelog-update-table-T_INFOS_MATCH-add-column-last_refresh_from_riot.yml
+  - include:
+      file: db/changelog/changes/db.changelog-update-table-T_PARTICIPANT_MATCH-add-column-pseudo.yml

--- a/Back/src/test/java/com/league/league_infos/mapper/ParticipantMatchMapperTest.java
+++ b/Back/src/test/java/com/league/league_infos/mapper/ParticipantMatchMapperTest.java
@@ -45,6 +45,7 @@ class ParticipantMatchMapperTest {
                 .neutralMinionsKilled(104)
                 .totalMinionsKilled(125)
                 .puuid("puuid")
+                .pseudo("Luuuna44")
                 .profileIcon(14)
                 .teamId(10)
                 .teamPosition("")
@@ -98,7 +99,9 @@ class ParticipantMatchMapperTest {
                         "item3",
                         "item4",
                         "item5",
-                        "item6")
+                        "item6",
+                        "pseudo"
+                )
                 .containsExactly(135L,
                         12,
                         98,
@@ -130,7 +133,9 @@ class ParticipantMatchMapperTest {
                         53,
                         54,
                         55,
-                        56);
+                        56,
+                        "Luuuna44"
+                );
 
         assertThat(result.getChallengesEntity()).isNotNull();
     }
@@ -340,6 +345,7 @@ class ParticipantMatchMapperTest {
         participantMatchEntity.setItem4(54);
         participantMatchEntity.setItem5(55);
         participantMatchEntity.setItem6(56);
+        participantMatchEntity.setPseudo("Luuuna44");
 
         ChallengesEntity challengesEntity = new ChallengesEntity();
         challengesEntity.setGameLength(1330F);
@@ -382,7 +388,9 @@ class ParticipantMatchMapperTest {
                         "item3",
                         "item4",
                         "item5",
-                        "item6")
+                        "item6",
+                        "pseudo"
+                )
                 .containsExactly(135,
                         12,
                         98,
@@ -414,7 +422,9 @@ class ParticipantMatchMapperTest {
                         53,
                         54,
                         55,
-                        56);
+                        56,
+                        "Luuuna44"
+                );
     }
 
     @Test

--- a/Back/src/test/java/com/league/league_infos/services/business/MatchDataProviderTest.java
+++ b/Back/src/test/java/com/league/league_infos/services/business/MatchDataProviderTest.java
@@ -1,13 +1,21 @@
 package com.league.league_infos.services.business;
 
 import com.league.league_infos.common.utils.CurrentLocalDateTime;
+import com.league.league_infos.dto.AccountDTO;
+import com.league.league_infos.dto.match.ChallengesDTO;
 import com.league.league_infos.dto.match.InfoMatchDTO;
 import com.league.league_infos.dto.match.MatchDTO;
+import com.league.league_infos.dto.match.MetadataDTO;
+import com.league.league_infos.dto.match.ParticipantMatchDTO;
+import com.league.league_infos.dto.match.TeamDTO;
 import com.league.league_infos.services.api.HistoryGamesService;
+import com.league.league_infos.services.riot.RiotAccountService;
 import com.league.league_infos.services.spi.HistoryPersistence;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +25,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -36,27 +46,24 @@ class MatchDataProviderTest {
     @Mock
     private CurrentLocalDateTime currentLocalDateTime;
 
+    @Mock
+    private RiotAccountService riotAccountService;
+
     @InjectMocks
     private MatchDataProvider matchDataProvider;
 
-    @Test
-    @DisplayName("Should call historyGamesService.getHistoryIds")
-    void getMatchsHistory_success_1() {
-
-        // WHEN
-        matchDataProvider.getMatchsHistory("puuid", 420);
-
-        // THEN
-        verify(historyGamesService, times(1)).getHistoryIds("puuid", 420);
-    }
+    @Captor
+    private ArgumentCaptor<List<MatchDTO>> listMatchArgumentCaptor;
 
     @Test
     @DisplayName("Should call historyPersistence.getMatchHistoryByGameIds and findAllMatchByPuuidAndQueue " +
             "do not call historyGamesService.getMatchHistory" +
             "do not call historyGamesService.getHistoryIds" +
+            "do not call riotAccountService.getAccountByPuuid" +
+            "do not call historyPersistence.persistAndRefreshFromRiotMatchHistory" +
             "case lastRefreshFromRiot < 12h"
     )
-    void getMatchsHistory_success_2() {
+    void getMatchsHistory_success_1() {
         // GIVEN
         MatchDTO matchDTO = new MatchDTO.Builder()
                 .info(new InfoMatchDTO.Builder()
@@ -72,26 +79,136 @@ class MatchDataProviderTest {
 
         // THEN
         verify(historyPersistence, times(1)).findAllMatchByPuuidAndQueue("puuid", 420);
+        verify(historyPersistence, never()).persistAndRefreshFromRiotMatchHistory(any());
         verify(historyGamesService, never()).getMatchHistory(any());
         verify(historyGamesService, never()).getHistoryIds(any(), any());
+        verify(riotAccountService, never()).getAccountByPuuid(any());
         assertThat(result).isNotEmpty().hasSize(1);
     }
 
     @Test
-    @DisplayName("Should call historyGamesService.getHistoryIds, historyPersistence.getMatchHistoryByGameIds and findAllMatchByPuuidAndQueue  " +
-            " historyGamesService.getMatchHistory case lastRefreshFromRiot > 12h")
-    void getMatchsHistory_success_3() {
+    @DisplayName("Should call historyGamesService.getHistoryIds, historyPersistence.persistAndRefreshFromRiotMatchHistory, historyPersistence.getMatchHistoryByGameIds, " +
+            "findAllMatchByPuuidAndQueue historyGamesService.getMatchHistory, accountDTO.getGameName() and get the pseudo from the current participant case lastRefreshFromRiot >" +
+            " 12h")
+    void getMatchsHistory_success_2() {
 
         // GIVEN
         MatchDTO matchDTO = new MatchDTO.Builder()
-                .info(new InfoMatchDTO.Builder()
-                        .lastRefreshFromRiot(LocalDateTime.of(2025, 8, 1, 10, 8, 14))
+                .metadata(new MetadataDTO.Builder()
+                        .matchId("200")
+                        .dataVersion("dataVersion")
+                        .participants(List.of("p1", "p2"))
                         .build())
+                .info(new InfoMatchDTO.Builder()
+                        .gameId(200L)
+                        .gameCreation(326L)
+                        .gameDuration(300L)
+                        .endOfGameResult("end of game result")
+                        .gameEndTimestamp(326L)
+                        .gameMode("classic")
+                        .gameName("game name")
+                        .gameType("Ranked")
+                        .gameVersion("game version")
+                        .mapId(10)
+                        .queueId(420)
+                        .lastRefreshFromRiot(LocalDateTime.of(2025, 10, 7, 23, 0, 0))
+                        .participants(List.of(
+                                new ParticipantMatchDTO.Builder()
+                                        .assists(13)
+                                        .deaths(5)
+                                        .kills(20)
+                                        .championId(125)
+                                        .championName("Shyvana")
+                                        .championTransform(0)
+                                        .champLevel(18)
+                                        .doubleKills(2)
+                                        .goldEarned(18566)
+                                        .item0(135)
+                                        .item1(136)
+                                        .item2(95)
+                                        .item3(77)
+                                        .item4(122)
+                                        .item5(123)
+                                        .item6(126)
+                                        .lane("JUNGLE")
+                                        .neutralMinionsKilled(104)
+                                        .pentaKills(1)
+                                        .puuid("puuid")
+                                        .pseudo("pseudo")
+                                        .profileIcon(13)
+                                        .participantId(1)
+                                        .quadraKills(0)
+                                        .role("")
+                                        .summoner1Id(27)
+                                        .summoner2Id(28)
+                                        .summonerName("")
+                                        .teamId(50)
+                                        .totalMinionsKilled(125)
+                                        .tripleKills(0)
+                                        .win(true)
+                                        .challenges(new ChallengesDTO.Builder()
+                                                .gameLength(326.0F)
+                                                .kda(3.0F)
+                                                .build())
+                                        .build(),
+                                new ParticipantMatchDTO.Builder()
+                                        .assists(5)
+                                        .deaths(10)
+                                        .kills(3)
+                                        .championId(98)
+                                        .championName("Garen")
+                                        .championTransform(0)
+                                        .champLevel(17)
+                                        .doubleKills(0)
+                                        .goldEarned(14056)
+                                        .item0(135)
+                                        .item1(136)
+                                        .item2(94)
+                                        .item3(75)
+                                        .item4(100)
+                                        .lane("TOP")
+                                        .neutralMinionsKilled(0)
+                                        .pentaKills(0)
+                                        .puuid("puuid1")
+                                        .profileIcon(36)
+                                        .participantId(2)
+                                        .quadraKills(0)
+                                        .role("")
+                                        .summoner1Id(27)
+                                        .summoner2Id(45)
+                                        .summonerName("")
+                                        .teamId(60)
+                                        .totalMinionsKilled(185)
+                                        .tripleKills(0)
+                                        .win(false)
+                                        .challenges(new ChallengesDTO.Builder()
+                                                .gameLength(326.0F)
+                                                .kda(3.0F)
+                                                .build())
+                                        .build()
+                        ))
+                        .teams(List.of(new TeamDTO.Builder()
+                                                .win(true)
+                                                .teamId(50)
+                                                .build(),
+                                        new TeamDTO.Builder()
+                                                .win(false)
+                                                .teamId(60)
+                                                .build()
+                                )
+                        ).build())
+                .build();
+
+
+        AccountDTO account = new AccountDTO.Builder()
+                .gameName("pseudo")
                 .build();
 
         when(historyGamesService.getHistoryIds(anyString(), any(Integer.class))).thenReturn(List.of("1", "2"));
         when(historyPersistence.findAllMatchByPuuidAndQueue(anyString(), any(Integer.class))).thenReturn(List.of(matchDTO));
         when(currentLocalDateTime.getCurrentLocalDateTime()).thenReturn(LocalDateTime.of(2025, 10, 10, 0, 0, 0));
+        when(historyGamesService.getMatchHistory(anyList())).thenReturn(List.of(matchDTO));
+        when(riotAccountService.getAccountByPuuid(anyString())).thenReturn(account);
 
         // WHEN
         List<MatchDTO> result = matchDataProvider.getMatchsHistory("puuid", 420);
@@ -100,12 +217,83 @@ class MatchDataProviderTest {
         verify(historyPersistence, times(1)).findAllMatchByPuuidAndQueue("puuid", 420);
         verify(historyGamesService, times(1)).getMatchHistory(List.of("1", "2"));
         verify(historyGamesService, times(1)).getHistoryIds("puuid", 420);
+        verify(riotAccountService, times(1)).getAccountByPuuid("puuid");
         assertThat(result).isNotEmpty().hasSize(1);
+
+        verify(historyPersistence, times(1)).persistAndRefreshFromRiotMatchHistory(listMatchArgumentCaptor.capture());
+
+        assertThat(listMatchArgumentCaptor.getValue()).isNotEmpty().hasSize(1);
+        assertThat(listMatchArgumentCaptor.getValue().getFirst().getMetadata()).isNotNull().extracting("matchId", "dataVersion")
+                .containsExactly("200", "dataVersion");
+
+        assertThat(listMatchArgumentCaptor.getValue().getFirst().getInfo()).isNotNull().extracting("endOfGameResult",
+                        "gameCreation",
+                        "gameDuration",
+                        "gameMode",
+                        "gameType",
+                        "gameEndTimestamp",
+                        "gameVersion",
+                        "queueId",
+                        "lastRefreshFromRiot",
+                        "mapId")
+                .containsExactly("end of game result",
+                        326L,
+                        300L,
+                        "classic",
+                        "Ranked",
+                        326L,
+                        "game version",
+                        420,
+                        LocalDateTime.of(2025, 10, 7, 23, 0, 0),
+                        10);
+
+        assertThat(listMatchArgumentCaptor.getValue().getFirst().getInfo().getTeams()).isNotEmpty().hasSize(2).extracting("win", "teamId")
+                .containsExactly(
+                        tuple(true, 50),
+                        tuple(false, 60)
+                );
+
+        assertThat(listMatchArgumentCaptor.getValue().getFirst().getInfo().getParticipants()).isNotEmpty().hasSize(2).extracting("assists",
+                "deaths",
+                "kills",
+                "championId",
+                "championName",
+                "championTransform",
+                "champLevel",
+                "doubleKills",
+                "goldEarned",
+                "item0",
+                "item1",
+                "item2",
+                "item3",
+                "item4",
+                "item5",
+                "item6",
+                "lane",
+                "neutralMinionsKilled",
+                "pentaKills",
+                "puuid",
+                "pseudo",
+                "profileIcon",
+                "participantId",
+                "quadraKills",
+                "role",
+                "summoner1Id",
+                "summoner2Id",
+                "summonerName",
+                "teamId",
+                "totalMinionsKilled",
+                "tripleKills",
+                "win"
+        ).containsExactly(
+                tuple(13, 5, 20, 125, "Shyvana", 0, 18, 2, 18566, 135, 136, 95, 77, 122, 123, 126, "JUNGLE", 104, 1, "puuid", "pseudo", 13, 1, 0, "", 27, 28, "", 50, 125, 0, true),
+                tuple(5, 10, 3, 98, "Garen", 0, 17, 0, 14056, 135, 136, 94, 75, 100, null, null, "TOP", 0, 0, "puuid1", null, 36, 2, 0, "", 27, 45, "", 60, 185, 0, false)
+        );
     }
 
     @Test
     @DisplayName("Should return an empty list if listGameids is null")
-    void getMatchsHistory_success_4() {
+    void getMatchsHistory_success_3() {
 
         // GIVEN
         when(historyGamesService.getHistoryIds(anyString(), any(Integer.class))).thenReturn(null);
@@ -119,7 +307,7 @@ class MatchDataProviderTest {
 
     @Test
     @DisplayName("Should return an empty list if listGameids is empty")
-    void getMatchsHistory_success_5() {
+    void getMatchsHistory_success_4() {
 
         // GIVEN
         when(historyGamesService.getHistoryIds(anyString(), any(Integer.class))).thenReturn(Collections.emptyList());

--- a/Front/src/app/common/models/games-history/matchDTO.ts
+++ b/Front/src/app/common/models/games-history/matchDTO.ts
@@ -61,6 +61,7 @@ export class ParticipantMatchDTO {
   lane!: string;
   role!: string;
   puuid!: string;
+  pseudo!: string;
   teamPosition!: string;
   win!: boolean;
   challenges!: ChallengeDTO;

--- a/Front/src/app/details/game-detail/game-detail.component.spec.ts
+++ b/Front/src/app/details/game-detail/game-detail.component.spec.ts
@@ -77,6 +77,7 @@ describe('GameDetailComponent', () => {
       teamPosition: '',
       win: true,
       matchId: 'mock-match-id-456',
+      pseudo: 'pseudo',
       challenges: {
         kda: 9.0,
         gameLength: 2555,
@@ -119,6 +120,7 @@ describe('GameDetailComponent', () => {
       teamPosition: '',
       win: true,
       matchId: 'mock-match-id-456',
+      pseudo: 'pseudo',
       challenges: {
         kda: 8.0,
         gameLength: 2555,

--- a/Front/src/app/details/player-details/player-details.component.spec.ts
+++ b/Front/src/app/details/player-details/player-details.component.spec.ts
@@ -136,6 +136,7 @@ function mockMatchParticipant() {
     teamPosition: '',
     win: true,
     matchId: '12345',
+    pseudo: 'pseudo',
     challenges: {
       kda: 9.0,
       gameLength: 2555,

--- a/Front/src/app/games-history/history-items/history-items.component.html
+++ b/Front/src/app/games-history/history-items/history-items.component.html
@@ -6,20 +6,20 @@
   <div class="col-1">
     <div class="champion-img-container">
       <img loading="lazy"
-          decoding="async" 
-          [src]="iconChampionUrl" 
-          alt="{{ currMatchParticipant.championName }}" 
+          decoding="async"
+          [src]="iconChampionUrl"
+          alt="{{ currMatchParticipant.championName }}"
           class="champion-icon" />
       <div data-test="champ-level" class="champion-level-circle">{{ currMatchParticipant.champLevel }}</div>
     </div>
     <div data-test="summoner-spells" class="summoner-spell-container">
       <img loading="lazy"
-          decoding="async" 
-          class="summoner-spell-icon" 
+          decoding="async"
+          class="summoner-spell-icon"
           [src]="summoner1IconUrl" />
       <img loading="lazy"
-          decoding="async" 
-          class="summoner-spell-icon" 
+          decoding="async"
+          class="summoner-spell-icon"
           [src]="summoner2IconUrl" />
     </div>
   </div>
@@ -35,17 +35,17 @@
     </div>
     <span data-test="gold-earned" class="gold ms-3">
       <img loading="lazy"
-          decoding="async" 
-          src="images/Icons/icon_gold.png" 
-          alt="Gold" 
+          decoding="async"
+          src="images/Icons/icon_gold.png"
+          alt="Gold"
           class="gold-icon" />
       {{ currMatchParticipant.goldEarned }}
     </span>
     <span data-test="nb-cs-kill" class="cs ms-3">
       <img loading="lazy"
-          decoding="async" 
-          src="images/Icons/icon_minions.png" 
-          alt="CS" 
+          decoding="async"
+          src="images/Icons/icon_minions.png"
+          alt="CS"
           class="cs-icon" />
       {{ nbCsKilled }}
     </span>
@@ -69,25 +69,25 @@
   <div class="col-1">
     <div class="champion-img-container">
       <img loading="lazy"
-          decoding="async" 
-          [src]="iconChampionUrl" 
-          alt="{{ currMatchParticipant.championName }}" 
+          decoding="async"
+          [src]="iconChampionUrl"
+          alt="{{ currMatchParticipant.championName }}"
           class="champion-icon" />
       <div data-test="champ-level" class="champion-level-circle">{{ currMatchParticipant.champLevel }}</div>
     </div>
     <div data-test="summoner-spells" class="summoner-spell-container">
       <img loading="lazy"
-          decoding="async" 
-          class="summoner-spell-icon" 
+          decoding="async"
+          class="summoner-spell-icon"
           [src]="summoner1IconUrl" />
       <img loading="lazy"
-          decoding="async" 
-          class="summoner-spell-icon" 
+          decoding="async"
+          class="summoner-spell-icon"
           [src]="summoner2IconUrl" />
     </div>
   </div>
   <div class="champion-info col-2">
-    <span>{{ accountDTOSignal()?.gameName}}</span>
+    <span>{{ currMatchParticipant.pseudo?currMatchParticipant.pseudo:'inconnu'}}</span>
     <span data-test="champion-name-selected" class="champion-name">{{ currMatchParticipant.championName }}</span>
     <span data-test="role" class="champion-role">{{ role }}</span>
   </div>
@@ -98,16 +98,16 @@
     </div>
     <span data-test="gold-earned" class="gold ms-3">
       <img loading="lazy"
-          decoding="async" 
-          src="images/Icons/icon_gold.png" 
-          alt="Gold" 
+          decoding="async"
+          src="images/Icons/icon_gold.png"
+          alt="Gold"
           class="gold-icon" />
       {{ currMatchParticipant.goldEarned }}
     </span>
     <span data-test="nb-cs-kill" class="cs ms-3">
       <img loading="lazy"
-          decoding="async" 
-          src="images/Icons/icon_minions.png" 
+          decoding="async"
+          src="images/Icons/icon_minions.png"
           alt="CS" class="cs-icon" />
       {{ nbCsKilled }}
     </span>
@@ -116,9 +116,9 @@
     @for(itemUrl of listUrlItems; let i = $index; track i){ @if(itemUrl.itemId != 0){
     <ng-container>
       <img loading="lazy"
-          decoding="async" 
-          [src]="itemUrl.url" 
-          alt="{{ itemUrl.itemId }}" 
+          decoding="async"
+          [src]="itemUrl.url"
+          alt="{{ itemUrl.itemId }}"
           class="item-icon" />
     </ng-container>
     }}

--- a/Front/src/app/games-history/history-items/history-items.component.spec.ts
+++ b/Front/src/app/games-history/history-items/history-items.component.spec.ts
@@ -4,7 +4,6 @@ import { HistoryItemsComponent } from './history-items.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MatchDTO, ParticipantMatchDTO } from '../../common/models/games-history/matchDTO';
-import { HistoryService } from '../../services/games-history/history.service';
 import { GetVersionsService } from '../../services/versions/get-versions.service';
 import { clickButtonByDataTestAttr, getByDataTestAttr } from '../../common/utils/utils-tests';
 import { signal } from '@angular/core';
@@ -13,7 +12,6 @@ import { provideRouter, Router } from '@angular/router';
 describe('HistoryItemsComponent', () => {
   let component: HistoryItemsComponent;
   let fixture: ComponentFixture<HistoryItemsComponent>;
-  let historyService: HistoryService;
   let versionService: GetVersionsService;
   let routerService: Router;
 
@@ -77,6 +75,7 @@ describe('HistoryItemsComponent', () => {
       lane: 'MIDDLE',
       role: 'SOLO',
       puuid: 'mock-puuid-123',
+      pseudo: 'joueur 1',
       teamPosition: '',
       win: true,
       matchId: 'mock-match-id-456',
@@ -94,7 +93,6 @@ describe('HistoryItemsComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(HistoryItemsComponent);
-    historyService = TestBed.inject(HistoryService);
     versionService = TestBed.inject(GetVersionsService);
     versionService.lastVersionlolDTOSignal.set('14.1');
     routerService = TestBed.inject(Router);

--- a/Front/src/app/games-history/history-items/history-items.component.ts
+++ b/Front/src/app/games-history/history-items/history-items.component.ts
@@ -55,7 +55,6 @@ export class HistoryItemsComponent implements OnInit, OnDestroy {
     this.summoner1IconUrl = this.computeSummonerSpellUrl(this.currMatchParticipant.summoner1Id);
     this.summoner2IconUrl = this.computeSummonerSpellUrl(this.currMatchParticipant.summoner2Id);
 
-    this.getAccountByPuuid();
     this.findCurrentPlayer();
   }
 
@@ -64,16 +63,6 @@ export class HistoryItemsComponent implements OnInit, OnDestroy {
     if (puuidFromUrl === this.currMatchParticipant.puuid) {
       this.isCurrentPlayerSignal.set(true);
     }
-  }
-
-  private getAccountByPuuid() {
-    this.playerService
-      .getAccountByPuuid(this.currMatchParticipant.puuid)
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (res) => this.accountDTOSignal.set(res),
-        error: (err) => console.log(err),
-      });
   }
 
   private getCurrentMatch(): MatchDTO | undefined {


### PR DESCRIPTION
- Suppression de l'appel api Riot depuis une partie historique pour récupérer le pseudo des joueurs.
- Script liquibase de création d'une colonne "pseudo" dans T_PARTICIPANT_MATCH
- Le pseudo du joueur cible est enregistrer en bdd et seul celui-ci sera renseigné sur l'IHM, les autres seront désormais "inconnu".
- Cela doit diminuer très largement les appels api riot
- Refacto ---> Déplacement de l'appel de persistence des parties.